### PR TITLE
Change main bower file to source instead of min

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angulartics-google-analytics",
-  "main": "./dist/angulartics-google-analytics.min.js",
+  "main": "lib/angulartics-google-analytics.js",
   "dependencies": {
     "angulartics": "~0.20"
   },


### PR DESCRIPTION
It is the convention to publish the source as the main file instead of the min version.

It's nice to bundle the min version but providing it by default causes problems with build pipelines that further process the file. For example, if you concat/uglify after, grunt-contrib-concat will complain that it needs the .map file. Depending on the build pipeline, that map file can not be available easily.

To be totally honest, I have no idea if this is a true convention or not, but I have 20+ dependencies in bower and this is the first time I see the min.js file as the main file and it crashed my build. :-)