### PR TITLE
Allow setting dimensions/metrics via setUserProperties()

### DIFF
--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -21,13 +21,15 @@ angular.module('angulartics.google.analytics', ['angulartics'])
   };
 
   function setDimensionsAndMetrics(properties) {
-    // add custom dimensions and metrics
-    for(var idx = 1; idx<=20;idx++) {
-      if (properties['dimension' +idx.toString()]) {
-        ga('set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
-      }
-      if (properties['metric' +idx.toString()]) {
-        ga('set', 'metric' +idx.toString(), properties['metric' +idx.toString()]);
+    if (window.ga) {
+      // add custom dimensions and metrics
+      for(var idx = 1; idx<=20;idx++) {
+        if (properties['dimension' +idx.toString()]) {
+          ga('set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
+        }
+        if (properties['metric' +idx.toString()]) {
+          ga('set', 'metric' +idx.toString(), properties['metric' +idx.toString()]);
+        }
       }
     }
   }

--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -20,6 +20,18 @@ angular.module('angulartics.google.analytics', ['angulartics'])
     userId: null
   };
 
+  function setDimensionsAndMetrics(properties) {
+    // add custom dimensions and metrics
+    for(var idx = 1; idx<=20;idx++) {
+      if (properties['dimension' +idx.toString()]) {
+        ga('set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
+      }
+      if (properties['metric' +idx.toString()]) {
+        ga('set', 'metric' +idx.toString(), properties['metric' +idx.toString()]);
+      }
+    }
+  }
+
   $analyticsProvider.registerPageTrack(function (path) {
     if (window._gaq) {
       _gaq.push(['_trackPageview', path]);
@@ -77,14 +89,8 @@ angular.module('angulartics.google.analytics', ['angulartics'])
       };
 
       // add custom dimensions and metrics
-      for(var idx = 1; idx<=20;idx++) {
-      if (properties['dimension' +idx.toString()]) {
-        eventOptions['dimension' +idx.toString()] = properties['dimension' +idx.toString()];
-      }
-      if (properties['metric' +idx.toString()]) {
-        eventOptions['metric' +idx.toString()] = properties['metric' +idx.toString()];
-        }
-      }
+      setDimensionsAndMetrics(properties);
+
       ga('send', 'event', eventOptions);
       angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
         ga(accountName +'.send', 'event', eventOptions);
@@ -99,6 +105,11 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 
   $analyticsProvider.registerSetUsername(function (userId) {
     $analyticsProvider.settings.ga.userId = userId;
+  });
+
+  $analyticsProvider.registerSetUserProperties(function (properties) {
+    // add custom dimensions and metrics
+    setDimensionsAndMetrics(properties);
   });
 
 }]);

--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -23,7 +23,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
   function setDimensionsAndMetrics(properties) {
     if (window.ga) {
       // add custom dimensions and metrics
-      for(var idx = 1; idx<=20;idx++) {
+      for(var idx = 1; idx<=200;idx++) {
         if (properties['dimension' +idx.toString()]) {
           ga('set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
         }


### PR DESCRIPTION
This allows pageView events to also have dimensions/metrics.

It uses the same properties structure as an event track:
```js
$analytics.setUserProperties({dimension1: 'some-kind-of-value'});
```

I've also upped the limit for custom directives to 200 to support premium accounts (thanks @OneHP for noticing).