### PR TITLE
custom dimensions and metrics should be set on additional account nam…

### DIFF
--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -26,9 +26,15 @@ angular.module('angulartics.google.analytics', ['angulartics'])
       for(var idx = 1; idx<=200;idx++) {
         if (properties['dimension' +idx.toString()]) {
           ga('set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
+          angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+            ga(accountName +'.set', 'dimension' +idx.toString(), properties['dimension' +idx.toString()]);
+          });
         }
         if (properties['metric' +idx.toString()]) {
           ga('set', 'metric' +idx.toString(), properties['metric' +idx.toString()]);
+          angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+            ga(accountName +'.set', 'metric' +idx.toString(), properties['metric' +idx.toString()]);
+          });
         }
       }
     }


### PR DESCRIPTION
…es as well as default tracker

I'm using additionalAccountNames to fire events on multiple trackers. If I set up a custom dimension I want it to be set on all trackers.