### PR TITLE
feat(ga): add support for setting transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Done. Open your app, browse across the different routes and check [the realtime 
 
 Documentation is available on the [Angulartics site](http://luisfarzati.github.io/angulartics).
 
+### Settings
+Module settings are done via the `$analyticsProvider.settings.ga` property.  The following are GA-specific properties:
+* `transport`
+  _(Default: `undefined`)_ -
+  sets the `transport` property for see the [GA Transport Documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport) for more information how to properly set this value.  This should be a string.
+
 ## Development
 
 ```shell

--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -93,7 +93,13 @@ angular.module('angulartics.google.analytics', ['angulartics'])
       // add custom dimensions and metrics
       setDimensionsAndMetrics(properties);
 
-      ga('send', 'event', eventOptions);
+      if ($analyticsProvider.settings.ga.transport) {
+        ga('send', 'event', eventOptions, { transport: $analyticsProvider.settings.ga.transport});
+      }
+      else {
+        ga('send', 'event', eventOptions);
+      }
+
       angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
         ga(accountName +'.send', 'event', eventOptions);
       });


### PR DESCRIPTION
* add support to allow the user to specify the transport used by `ga`.

Fixes #20