### PR TITLE
analytics-action isn't working

### DIFF
--- a/lib/angulartics-google-analytics.js
+++ b/lib/angulartics-google-analytics.js
@@ -82,7 +82,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 
       var eventOptions = {
         eventCategory: properties.category,
-        eventAction: action,
+        eventAction: properties.action,
         eventLabel: properties.label,
         eventValue: properties.value,
         nonInteraction: properties.noninteraction,


### PR DESCRIPTION
The analytics-action ignores the content of the data attribute, and uses the internal text of the element instead. using 'properties.action' solves the problem