### PR TITLE
Add "version" to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "angulartics-google-analytics",
+  "version": "0.1.4",
   "main": "lib/angulartics-google-analytics.js",
   "dependencies": {
     "angulartics": "~1.0.0"


### PR DESCRIPTION
If there's no "version", bower will install the latest angulartics-google-analytics instead of specific version in my bower.json. And the lastest angulartics-google-analytics would have conflict with angulartics v0.20.