### PR TITLE
Adding hitCallback option

### DIFF
--- a/lib/angulartics-ga.js
+++ b/lib/angulartics-ga.js
@@ -81,6 +81,12 @@ angular.module('angulartics.google.analytics', ['angulartics'])
       properties.value = isNaN(parsed) ? 0 : parsed;
     }
 
+    // GA requires that hitCallback be an function, see:
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#hitcallback
+    if (properties.hitCallback && (typeof properties.hitCallback !== 'function')) {
+      properties.hitCallback = null;
+    }
+
     if (window.ga) {
 
       var eventOptions = {
@@ -90,7 +96,8 @@ angular.module('angulartics.google.analytics', ['angulartics'])
         eventValue: properties.value,
         nonInteraction: properties.noninteraction,
         page: properties.page || window.location.hash.substring(1) || window.location.pathname,
-        userId: $analyticsProvider.settings.ga.userId
+        userId: $analyticsProvider.settings.ga.userId,
+        hitCallback: properties.hitCallback
       };
 
       // Round up any dimensions and metrics for this hit
@@ -136,7 +143,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    * Set Username
    * @name setUsername
    *
-   * @param {string} userId Registers User ID of user for use with other hits 
+   * @param {string} userId Registers User ID of user for use with other hits
    *
    * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#user_id
    */
@@ -148,7 +155,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    * Set User Properties
    * @name setUserProperties
    *
-   * @param {object} properties Sets all properties with dimensionN or metricN to their respective values 
+   * @param {object} properties Sets all properties with dimensionN or metricN to their respective values
    *
    * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#customs
    */
@@ -156,7 +163,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
     if(properties) {
       // add custom dimensions and metrics to each hit
       var dimsAndMets = dimensionsAndMetrics(properties);
-      ga('set', dimsAndMets); 
+      ga('set', dimsAndMets);
     }
   });
 


### PR DESCRIPTION
We are trying to track outbound links with angulartics, and we are using the recommended way:
https://support.google.com/analytics/answer/1136920?hl=en
Using the `hitCallback` parameter:
https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#hitcallback

Because is not implemented in this plugin we need to make this tracking using directly `windows.ga`. 

I hope you find it useful so we can continue using angulartics. Let me know any issue regarding this.