### PR TITLE
Disable logging when no GA is found.

### DIFF
--- a/lib/angulartics-ga.js
+++ b/lib/angulartics-ga.js
@@ -356,7 +356,6 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 
     // If neither has been detected, GA is not above the angular code
     if (!handler) {
-      console.log('Error: neither Classic nor Universal Analytics detected at bootstrap. Angulartics-GA will ignore all commands!');
       return angular.noop;
     }
 


### PR DESCRIPTION
Hello!!

We are using Angulartics in our project. However when running GRUNT KARMA we have many many console.log messages when executing those test, hence I disabled console.log for that.