### PR TITLE
Silently skip eventTrack when action is empty

### DIFF
--- a/lib/angulartics-ga.js
+++ b/lib/angulartics-ga.js
@@ -73,7 +73,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
     if ($analyticsProvider.settings.ga.disableEventTracking) return;
 
     if (!action && action + '' !== '0') {
-      return console.log('Missing required argument action');
+      return;
     }
 
     // Sets default properties


### PR DESCRIPTION
Sometimes the event is conditional, and setting the analytics-event directive to empty is the only way to do that.
Either way, the previous message didn't lead to angulartics, thus starting a long research as to where this pops up from.
