### PR TITLE
Custom event action specification.

### DIFF
--- a/lib/angulartics-ga.js
+++ b/lib/angulartics-ga.js
@@ -103,7 +103,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
     dispatchToGa('event', 'send', angular.extend({}, properties, {
       hitType: 'event',
       eventCategory: properties.category,
-      eventAction: action,
+      eventAction: properties.action || action,
       eventLabel: properties.label,
       eventValue: properties.value,
       nonInteraction: properties.nonInteraction,


### PR DESCRIPTION
Functionality to specify custom ` eventAction` value for certain use cases where the action name is different from the HTML element text with which interaction takes place. In the absence of the specification, the `eventAction` value is inferred from the html text of the element as usual.