### PR TITLE
Fix for broken Multi GA Accounts

### DIFF
--- a/lib/angulartics-ga.js
+++ b/lib/angulartics-ga.js
@@ -474,7 +474,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 
         angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
        
-          commandClone[0] = accountName + '.' + commandClone[0];
+          commandClone[0] = accountName + '.' + commandArray[0];
 
           window[gaNamespace].apply(this, commandClone);
 


### PR DESCRIPTION
Multi GA Accounts were broken.
The AccountNames were appending one fully formed account names.
AccountNname should append the command been passed send/set etc..,  